### PR TITLE
Do not monitor Description/Activity/Entry Name

### DIFF
--- a/plugin/main.js
+++ b/plugin/main.js
@@ -86,8 +86,8 @@ function refreshButtons() {
         if (entryData //Does button match the active timer?
             && entryData.workspace_id == settings.workspaceId
             && (entryData.project_id ?? 0) == settings.projectId
-            && (entryData.task_id ?? 0) == settings.taskId
-            && entryData.description == settings.activity) {
+            && (entryData.task_id ?? 0) == settings.taskId )
+            {
           setState(context, 0)
           setTitle(context, `${formatElapsed(entryData.start)}\n\n\n${settings.label}`)
         } else { //if not, make sure it's 'off'
@@ -127,7 +127,7 @@ async function toggle(context, settings) {
     if (!entryData) {
       //Not running? Start a new one
       startEntry(apiToken, activity, workspaceId, projectId, taskId, billableToggle).then(v=>refreshButtons())
-    } else if (entryData.workspace_id == workspaceId && (entryData.project_id ?? 0) == projectId && (entryData.task_id ?? 0) == taskId && entryData.description == activity) {
+    } else if (entryData.workspace_id == workspaceId && (entryData.project_id ?? 0) == projectId && (entryData.task_id ?? 0) == taskId ) { 
       //The one running is "this one" -- toggle to stop
       stopEntry(apiToken, entryData.id, workspaceId).then(v=>refreshButtons())
     } else {


### PR DESCRIPTION
For me <ins>personally</ins>, I had thefollowing issue, what I was able to fix with this modification:

- I track my time on projects, but my activities/descriptions vary a lot, so i don't want to set these via Stream Deck, but rather go into the wtoggle web interface and set the description there.
- With the original code of the plugin, I had the issue that after I entered the description in the web interface of toggle, the button went "off"

With this modification I removed the monitoring of the "Description"/"Activity"/"Entry Name" value. (_side question: Why is it called different in toggle vs. the plugin code, vs. the plugin gui?_)
![image](https://github.com/user-attachments/assets/8b977bc8-eb97-4d5f-b130-8591cf637449)

Why is this "exact check" needed anyway? As with toggle it is not possible to track multiple times simultaneously.  I beleve this is only used to check: "is the timer active or not"


Please be aware that I am not aware that this fits to all workflows!

**Idea for improvement:** 
- Add a checkbox/option in the plugin, if the desciption/activity should be considered. 
