### PR TITLE
Add fallback button feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Download the latest .streamDeckPlugin file from [Releases](https://github.com/bl
 * **Entry Name** describes the activity you want to report. It is not required but strongly recommended.
 * **Workspace** is your workspace you start the time entries in. Required.
 * **Project** is the project you want to assign the task to. Leave blank for no project. New projects can be added in Toggl.
+* **Fallback** designates this button as a fallback button. A fallback button starts a defined activity as normal (e.g. "TBD"), but will indicate and stop any activity that's not handled by another button.
 * **Billable** sets Toggl's billable flag (for Toggl paid plans only).
 
 ![StreamDeckScreenshot](resources/readme/StreamDeckScreenshot.png)

--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -57,6 +57,13 @@
         <option value="0"></option>
       </select>
     </div>
+    <div class="sdpi-item invalidHidden hidden" id="fallbackWrapper">
+      <div class="sdpi-item-label">Fallback/Default task</div>
+      <select class="sdpi-item-value select" id="fallback" onchange="sendSettings()">
+        <option value="0" selected>No</option>
+        <option value="1">Yes (active when no other button is active)</option>
+      </select>
+    </div>
     <div class="sdpi-item invalidHidden hidden" id="billableWrapper">
       <div class="sdpi-item-label">Billable</div>
       <select class="sdpi-item-value select" id="billable" onchange="sendSettings()">

--- a/pi/main_pi.js
+++ b/pi/main_pi.js
@@ -35,6 +35,7 @@ function connectElgatoStreamDeckSocket (inPort, inPropertyInspectorUUID, inRegis
       if (payload.label) document.getElementById('label').value = payload.label
       if (payload.activity) document.getElementById('activity').value = payload.activity
       document.getElementById('billable').value = payload.billableToggle ? 1 : 0
+      document.getElementById('fallback').value = payload.fallbackToggle ? 1 : 0
 
       const apiToken = document.getElementById('apitoken').value
 
@@ -73,7 +74,8 @@ function sendSettings () {
       workspaceId: document.getElementById('wid').value,
       projectId: document.getElementById('pid').value,
       taskId: document.getElementById('tid').value,
-      billableToggle: document.getElementById('billable').value == 1 ?  true : false
+      billableToggle: document.getElementById('billable').value == 1 ?  true : false,
+      fallbackToggle: document.getElementById('fallback').value == 1 ?  true : false
     }
   }))
 }
@@ -124,6 +126,7 @@ async function updateProjects (apiToken, workspaceId) {
       document.getElementById('workspaceError').classList.add('hiddenError')
       document.getElementById('projectWrapper').classList.remove('hidden')
       document.getElementById('billableWrapper').classList.remove('hidden')
+      document.getElementById('fallbackWrapper').classList.remove('hidden')
       const selectEl = document.getElementById('pid')
 
       if (projectsData != null) projectsData.sort((a, b) => { return (a.active === b.active) ? 0 : a.active ? -1 : 1; });
@@ -139,6 +142,7 @@ async function updateProjects (apiToken, workspaceId) {
     document.getElementById('taskWrapper').classList.add('hidden')
     document.getElementById('projectWrapper').classList.add('hidden')
     document.getElementById('billableWrapper').classList.add('hidden')
+    document.getElementById('fallbackWrapper').classList.add('hidden')
   }
 }
 


### PR DESCRIPTION
This adds a feature to designate a button or buttons as "Fallback", meaning they track all running activities not assigned to any other button.

Use case: I have a couple buttons "Project A", "Project B", and "Project C" for the most common projects, and "TBD" (to be done) for any other time to be tracked. I mark "TBD" as fallback. When I start using time, I press TBD and it starts counting right away. Then at some point, I can update the description or project assignment in the toggle (web)app. The button will continue to track this time and update its label to reflect the currently running tasks.

Alternate usage: I can also start any activity outside of streamdeck and the fallback button will track it.

Caveat: I think the "not assigned to any other buttons" part only works for buttons currently visible.