### PR TITLE
Add tag support to time entries (closes #9)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,7 @@
 	"Icon": "resources/pluginIcon",
 	"PropertyInspectorPath": "pi/main_pi.html",
 	"URL": "https://github.com/blueshiftone/streamdeck-toggl",
-	"Version": "1.7.1.0",
+	"Version": "1.7.2.0",
 	"OS": [
 		{
 			"Platform": "mac",

--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -10,6 +10,68 @@
     .hidden, .hiddenError, .hiddenAll {
       display: none;
     }
+    #tagDropdown {
+      padding: 0 !important;
+    }
+    .tag-toggle {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      min-height: 26px;
+      box-sizing: border-box;
+      padding: 0 20px 0 4px;
+      cursor: pointer;
+      border: 1pt solid #303030;
+      border-radius: var(--sdpi-borderradius);
+      background: var(--sdpi-background) url(caret.svg) no-repeat 97% center;
+      color: var(--sdpi-color);
+      user-select: none;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    #tagPanel {
+      border: 1pt solid #303030;
+      border-top: none;
+      background: var(--sdpi-background);
+      border-radius: var(--sdpi-borderradius);
+    }
+    #tagSearch {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 3px 4px;
+      background: rgba(0,0,0,0.2);
+      border: none;
+      border-bottom: 1pt solid #303030;
+      color: var(--sdpi-color);
+      outline: none;
+    }
+    #tagList {
+      max-height: 88px;
+      overflow-y: auto;
+    }
+    .tag-item {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      padding: 3px 4px;
+      color: var(--sdpi-color);
+      cursor: pointer;
+    }
+    .tag-item:hover {
+      background: rgba(255,255,255,0.08);
+    }
+    .tag-item input[type="checkbox"] {
+      display: inline-block !important;
+      -webkit-appearance: auto !important;
+      appearance: auto !important;
+      width: 12px;
+      height: 12px;
+      margin: 0;
+      cursor: pointer;
+      accent-color: #e01b5d;
+      flex-shrink: 0;
+    }
   </style>
 </head>
 
@@ -64,8 +126,15 @@
     </div>
     <div class="sdpi-item invalidHidden hidden" id="tagWrapper">
       <div class="sdpi-item-label">Tags</div>
-      <select class="sdpi-item-value select" id="tags" multiple size="4" onchange="sendSettings()">
-      </select>
+      <div class="sdpi-item-value" id="tagDropdown">
+        <div class="tag-toggle" id="tagToggle" onclick="toggleTagDropdown()">
+          <span id="tagPreview"></span>
+        </div>
+        <div class="hidden" id="tagPanel">
+          <input type="text" id="tagSearch" placeholder="Search..." oninput="filterTags()" autocomplete="off">
+          <div id="tagList"></div>
+        </div>
+      </div>
     </div>
     <div class="sdpi-item invalidHidden hidden" id="billableWrapper">
       <div class="sdpi-item-label">Billable</div>

--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -62,6 +62,11 @@
         <option value="0"></option>
       </select>
     </div>
+    <div class="sdpi-item invalidHidden hidden" id="tagWrapper">
+      <div class="sdpi-item-label">Tags</div>
+      <select class="sdpi-item-value select" id="tags" multiple size="4" onchange="sendSettings()">
+      </select>
+    </div>
     <div class="sdpi-item invalidHidden hidden" id="billableWrapper">
       <div class="sdpi-item-label">Billable</div>
       <select class="sdpi-item-value select" id="billable" onchange="sendSettings()">

--- a/pi/main_pi.js
+++ b/pi/main_pi.js
@@ -54,7 +54,15 @@ function connectElgatoStreamDeckSocket (inPort, inPropertyInspectorUUID, inRegis
               updateTasks(apiToken, payload.workspaceId, payload.projectId).then(e => {
                 if (payload.taskId)
                   document.getElementById('tid').value = payload.taskId
+              })
+            }
+          })
 
+          updateTags(apiToken, payload.workspaceId).then(() => {
+            if (payload.tagIds && payload.tagIds.length > 0) {
+              const tagSelect = document.getElementById('tags')
+              Array.from(tagSelect.options).forEach(o => {
+                o.selected = payload.tagIds.includes(Number(o.value))
               })
             }
           })
@@ -77,6 +85,7 @@ function sendSettings () {
       workspaceId: document.getElementById('wid').value,
       projectId: document.getElementById('pid').value,
       taskId: document.getElementById('tid').value,
+      tagIds: Array.from(document.getElementById('tags').selectedOptions).map(o => Number(o.value)),
       billableToggle: document.getElementById('billable').value == 1 ?  true : false,
       trackingMode: document.getElementById('trackingmode').value
     }
@@ -93,6 +102,7 @@ function setAPIToken () {
 function setWorkspace () {
   document.getElementById('workspaceError').classList.add('hiddenError')
   updateProjects(document.getElementById('apitoken').value, document.getElementById('wid').value)
+  updateTags(document.getElementById('apitoken').value, document.getElementById('wid').value)
   sendSettings()
 }
 
@@ -151,6 +161,30 @@ async function updateProjects (apiToken, workspaceId) {
   }
 }
 
+async function updateTags (apiToken, workspaceId) {
+  try {
+    await getTags(apiToken, workspaceId).then(tagsData => {
+      const selectEl = document.getElementById('tags')
+      selectEl.innerHTML = ''
+      if (tagsData.length > 0) {
+        tagsData.sort((a, b) => a.name.localeCompare(b.name))
+        for (const tag of tagsData) {
+          const optionEl = document.createElement('option')
+          optionEl.innerText = tag.name
+          optionEl.value = tag.id.toString()
+          selectEl.append(optionEl)
+        }
+        document.getElementById('tagWrapper').classList.remove('hidden')
+      } else {
+        document.getElementById('tagWrapper').classList.add('hidden')
+      }
+    })
+  } catch (e) {
+    document.getElementById('tagWrapper').classList.add('hidden')
+    log("Error in updateTags: " + (e instanceof Error ? e.message : typeof e === "string" ? e : String(e)))
+  }
+}
+
 async function updateWorkspaces (apiToken) {
   try {
     await getWorkspaces(apiToken).then(workspaceData => {
@@ -178,6 +212,7 @@ async function updateWorkspaces (apiToken) {
     document.getElementById('activityWrapper').classList.add('hidden')
     document.getElementById('projectWrapper').classList.add('hidden')
     document.getElementById('taskWrapper').classList.add('hidden')
+    document.getElementById('tagWrapper').classList.add('hidden')
     document.getElementById('workspaceError').classList.add('hiddenError')
     log("Error in updateWorkspaces: " + (e instanceof Error ? e.message : typeof e === "string" ? e : String(e)))
   }
@@ -196,6 +231,19 @@ function openPage (site) {
       url: 'https://' + site
     }
   }))
+}
+
+async function getTags(apiToken, workspaceId) {
+  const key = `tags:${apiToken}:${workspaceId}`
+  return withCache(key, async () => {
+    const response = await fetch(
+      `${togglBaseUrl}/workspaces/${workspaceId}/tags`,
+      { headers: { Authorization: `Basic ${btoa(`${apiToken}:api_token`)}` } }
+    )
+    if (!response.ok) throw new Error(`Toggl API Error: ${await response.text()} (${response.status})`)
+    const json = await response.json()
+    return Array.isArray(json) ? json : []
+  })
 }
 
 async function getTasks(apiToken, workspaceId, projectId) {

--- a/pi/main_pi.js
+++ b/pi/main_pi.js
@@ -60,10 +60,10 @@ function connectElgatoStreamDeckSocket (inPort, inPropertyInspectorUUID, inRegis
 
           updateTags(apiToken, payload.workspaceId).then(() => {
             if (payload.tagIds && payload.tagIds.length > 0) {
-              const tagSelect = document.getElementById('tags')
-              Array.from(tagSelect.options).forEach(o => {
-                o.selected = payload.tagIds.includes(Number(o.value))
+              document.querySelectorAll('#tagList input[type="checkbox"]').forEach(cb => {
+                cb.checked = payload.tagIds.includes(Number(cb.value))
               })
+              updateTagPreview()
             }
           })
         }
@@ -85,7 +85,7 @@ function sendSettings () {
       workspaceId: document.getElementById('wid').value,
       projectId: document.getElementById('pid').value,
       taskId: document.getElementById('tid').value,
-      tagIds: Array.from(document.getElementById('tags').selectedOptions).map(o => Number(o.value)),
+      tagIds: Array.from(document.querySelectorAll('#tagList input:checked')).map(cb => Number(cb.value)),
       billableToggle: document.getElementById('billable').value == 1 ?  true : false,
       trackingMode: document.getElementById('trackingmode').value
     }
@@ -164,26 +164,60 @@ async function updateProjects (apiToken, workspaceId) {
 async function updateTags (apiToken, workspaceId) {
   try {
     await getTags(apiToken, workspaceId).then(tagsData => {
-      const selectEl = document.getElementById('tags')
-      selectEl.innerHTML = ''
+      const listEl = document.getElementById('tagList')
+      listEl.innerHTML = ''
       if (tagsData.length > 0) {
         tagsData.sort((a, b) => a.name.localeCompare(b.name))
         for (const tag of tagsData) {
-          const optionEl = document.createElement('option')
-          optionEl.innerText = tag.name
-          optionEl.value = tag.id.toString()
-          selectEl.append(optionEl)
+          const label = document.createElement('label')
+          label.className = 'tag-item'
+          const cb = document.createElement('input')
+          cb.type = 'checkbox'
+          cb.value = tag.id.toString()
+          cb.dataset.name = tag.name
+          cb.onchange = () => { updateTagPreview(); sendSettings() }
+          label.appendChild(cb)
+          label.appendChild(document.createTextNode(tag.name))
+          listEl.appendChild(label)
         }
         document.getElementById('tagWrapper').classList.remove('hidden')
       } else {
         document.getElementById('tagWrapper').classList.add('hidden')
       }
+      updateTagPreview()
     })
   } catch (e) {
     document.getElementById('tagWrapper').classList.add('hidden')
     log("Error in updateTags: " + (e instanceof Error ? e.message : typeof e === "string" ? e : String(e)))
   }
 }
+
+function toggleTagDropdown () {
+  const panel = document.getElementById('tagPanel')
+  const isOpen = !panel.classList.contains('hidden')
+  panel.classList.toggle('hidden', isOpen)
+  if (!isOpen) document.getElementById('tagSearch').focus()
+}
+
+function filterTags () {
+  const query = document.getElementById('tagSearch').value.toLowerCase()
+  document.querySelectorAll('#tagList .tag-item').forEach(item => {
+    const name = item.querySelector('input').dataset.name.toLowerCase()
+    item.style.display = name.includes(query) ? '' : 'none'
+  })
+}
+
+function updateTagPreview () {
+  const names = Array.from(document.querySelectorAll('#tagList input:checked')).map(cb => cb.dataset.name)
+  document.getElementById('tagPreview').textContent = names.join(', ')
+}
+
+document.addEventListener('click', function (e) {
+  const dropdown = document.getElementById('tagDropdown')
+  if (dropdown && !dropdown.contains(e.target)) {
+    document.getElementById('tagPanel')?.classList.add('hidden')
+  }
+})
 
 async function updateWorkspaces (apiToken) {
   try {

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -182,25 +182,25 @@ function leadingZero(val) {
 }
 
 async function toggle(settings) {
-  const { apiToken, apiFrequency, activity, taskId, projectId, workspaceId, billableToggle, trackingMode } = settings
+  const { apiToken, apiFrequency, activity, taskId, projectId, workspaceId, billableToggle, trackingMode, tagIds } = settings
 
   if (!currentTimeEntry) {
     // Not running? Start a new one
-    await startEntry(apiToken, activity, workspaceId, projectId, taskId, billableToggle).then(v=>refreshButtons())
+    await startEntry(apiToken, activity, workspaceId, projectId, taskId, billableToggle, tagIds).then(v=>refreshButtons())
   } else {
     if (matchWithFallback(currentTimeEntry, settings)) {
       // The one running is "this one" - toggle to stop
       await stopEntry(apiToken, currentTimeEntry.id, workspaceId).then(v=>refreshButtons())
     } else {
       // Just start the new one, old one will stop automatically
-      await startEntry(apiToken, activity, workspaceId, projectId, taskId, billableToggle).then(v=>refreshButtons())
+      await startEntry(apiToken, activity, workspaceId, projectId, taskId, billableToggle, tagIds).then(v=>refreshButtons())
     }
   }
 }
 
 // Toggl API Helpers
 
-async function startEntry(apiToken = isRequired(), activity = "Time Entry created by Toggl for Stream Deck", workspaceId = 0, projectId = 0, taskId = 0, billableToggle = false
+async function startEntry(apiToken = isRequired(), activity = "Time Entry created by Toggl for Stream Deck", workspaceId = 0, projectId = 0, taskId = 0, billableToggle = false, tagIds = []
 ) {
   try {
     const date = new Date();
@@ -215,6 +215,7 @@ async function startEntry(apiToken = isRequired(), activity = "Time Entry create
 
     if (projectId && projectId != 0) body.project_id = Number(projectId);
     if (taskId && taskId != 0) body.task_id = Number(taskId);
+    if (Array.isArray(tagIds) && tagIds.length > 0) body.tag_ids = tagIds.map(Number);
 
     const response = await fetch(
       `${togglBaseUrl}/workspaces/${workspaceId}/time_entries`, {


### PR DESCRIPTION
Fetches workspace tags from the Toggl API and shows a multi-select in
the property inspector. Selected tag IDs are saved with button settings
and passed as tag_ids when starting a time entry.

https://claude.ai/code/session_01AmSeh3ThiqMQQHQJwHLKra