### PR TITLE
Add 'Starts With Description' tracking mode (closes #14)

### DIFF
--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -73,6 +73,7 @@
       <div class="sdpi-item-label">Tracking Mode</div>
       <select class="sdpi-item-value select" id="trackingmode" onchange="sendSettings()">
         <option value="0" selected>Exact Match</option>
+        <option value="3">Starts With Description</option>
         <option value="1">Match Ignoring Description</option>
         <option value="2">Fallback (if no other button matches)</option>
       </select>

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -95,7 +95,7 @@ function matchButton(entry, button) {
     && entry.workspace_id == button.workspaceId 
     && (entry.project_id ?? 0) == button.projectId 
     && (entry.task_id ?? 0) == button.taskId 
-    && (entry.description == button.activity || button.trackingMode == 1)
+    && (entry.description == button.activity || button.trackingMode == 1 || (button.trackingMode == 3 && button.activity && entry.description?.startsWith(button.activity)))
   )
 }
 


### PR DESCRIPTION
Closes [#14](https://github.com/blueshiftone/streamdeck-toggl/issues/14)

Adds a new Starts With Description tracking mode (value 3). When selected, a button matches any running timer whose description begins with the button's configured activity label — so a button set to "Project A" will match "Project A: client call", "Project A: scheduling", etc.

Changes:

pi/main_pi.html — new option in the Tracking Mode dropdown
plugin/main.js — matchButton() handles trackingMode == 3 using String.startsWith()